### PR TITLE
fix issue #5 & optimize ATtiny85 demo example

### DIFF
--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -377,7 +377,7 @@ void TM1637TinyDisplay::showString(const char s[], uint8_t length, uint8_t pos)
       setSegments(digits, length, pos);
       delay(m_scrollDelay);
     }
-    for (int x = 3; x < strlen(s); x++) { // Scroll through string
+    for (size_t x = 3; x < strlen(s); x++) { // Scroll through string
       digits[0] = encodeASCII(s[x - 3]);
       digits[1] = encodeASCII(s[x - 2]);
       digits[2] = encodeASCII(s[x - 1]);

--- a/examples/ATtiny85/ATtiny85.ino
+++ b/examples/ATtiny85/ATtiny85.ino
@@ -347,11 +347,10 @@ void loop() {
   }
 
   // Demo Brightness Levels
-  char string[10];
   for (int x = 0; x < 8; x++) {
     display.setBrightness(x);
-    sprintf(string, "On %d", x);
-    display.showString(string);
+    display.showString("On ");
+    display.showNumber(x, false, 1, 3);
     delay(1000);
   }
 


### PR DESCRIPTION
This fixes issue #5 and saves ~1.5kB in the t85 example by using showNumber() instead of sprintf().
Changes tested with Arduino IDE 1.8.13 with a UNO clone.
