### PR TITLE
enable brightness direct write

### DIFF
--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -189,6 +189,11 @@ void TM1637TinyDisplay::flipDisplay(bool flip)
 void TM1637TinyDisplay::setBrightness(uint8_t brightness, bool on)
 {
   m_brightness = (brightness & 0x07) | (on? 0x08 : 0x00);
+  
+    // Write COMM3 + brightness
+  start();
+  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
+  stop();
 }
 
 void TM1637TinyDisplay::setScrolldelay(unsigned int scrollDelay)
@@ -230,10 +235,6 @@ void TM1637TinyDisplay::setSegments(const uint8_t segments[], uint8_t length, ui
   }
   stop();
 
-  // Write COMM3 + brightness
-  start();
-  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
-  stop();
 }
 
 void TM1637TinyDisplay::clear()

--- a/TM1637TinyDisplay6.cpp
+++ b/TM1637TinyDisplay6.cpp
@@ -191,6 +191,11 @@ void TM1637TinyDisplay6::flipDisplay(bool flip)
 void TM1637TinyDisplay6::setBrightness(uint8_t brightness, bool on)
 {
   m_brightness = (brightness & 0x07) | (on? 0x08 : 0x00);
+  
+  // Write COMM3 + brightness
+  start();
+  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
+  stop();
 }
 
 void TM1637TinyDisplay6::setScrolldelay(unsigned int scrollDelay)
@@ -239,10 +244,6 @@ void TM1637TinyDisplay6::setSegments(const uint8_t segments[], uint8_t length, u
   }
   stop();
 
-  // Write COMM3 + brightness
-  start();
-  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
-  stop();
 }
 
 void TM1637TinyDisplay6::clear()

--- a/TM1637TinyDisplayB.cpp
+++ b/TM1637TinyDisplayB.cpp
@@ -192,6 +192,11 @@ void TM1637TinyDisplayB::flipDisplay(bool flip)
 void TM1637TinyDisplayB::setBrightness(uint8_t brightness, bool on)
 {
   m_brightness = (brightness & 0x07) | (on? 0x08 : 0x00);
+  
+  // Write COMM3 + brightness
+  start();
+  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
+  stop();
 }
 
 void TM1637TinyDisplayB::setScrolldelay(unsigned int scrollDelay)
@@ -232,10 +237,6 @@ void TM1637TinyDisplayB::writeBuffer()
   }
   stop();
 
-  // Write COMM3 + brightness
-  start();
-  writeByte(TM1637_I2C_COMM3 + (m_brightness & 0x0f));
-  stop();
 }
 
 void TM1637TinyDisplayB::readBuffer(uint8_t *buffercopy)


### PR DESCRIPTION
By simply moving the writing of the TM1637_I2C_COMM3 into the setBrightness, the command becomes instantaneous and allows the brightness to be varied or the display to be turned off or on without rewriting a message after the setBrightness.