### PR TITLE
Updated library operation with new begin() method

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes for TM1637TinyDisplay
 
+## v1.8.0 - Updated library operation with new begin() method
+
+* Updated library operation to include an initializing method `begin()` to move outside the constructor hardware related calls, as reported in https://github.com/jasonacox/TM1637TinyDisplay/issues/28
+
 ## v1.7.1 - Fix Compile Errors for ESP8266
 
 * Fix compile errors and warnings on ESP8266 cores (type casts and erroneous defaults in functions) as reported in https://github.com/jasonacox/TM1637TinyDisplay/issues/26

--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -182,6 +182,7 @@ void TM1637TinyDisplay::begin()
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
+  clear();
 }
 
 void TM1637TinyDisplay::flipDisplay(bool flip)

--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -172,14 +172,16 @@ TM1637TinyDisplay::TM1637TinyDisplay(uint8_t pinClk, uint8_t pinDIO, unsigned in
   m_scrollDelay = scrollDelay;
   // Flip 
   m_flipDisplay = flip;
-  
+}
+
+void TM1637TinyDisplay::begin()
+{
   // Set the pin direction and default value.
   // Both pins are set as inputs, allowing the pull-up resistors to pull them up
   pinMode(m_pinClk, INPUT);
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
-  clear();
 }
 
 void TM1637TinyDisplay::flipDisplay(bool flip)

--- a/TM1637TinyDisplay.h
+++ b/TM1637TinyDisplay.h
@@ -117,8 +117,7 @@
 class TM1637TinyDisplay {
 
 public:
-  //! Initialize a TM1637TinyDisplay object, setting the clock and
-  //! data pins.
+  //! Initialize a TM1637TinyDisplay object.
   //!
   //! @param pinClk - The number of the digital pin connected to the clock pin of the module
   //! @param pinDIO - The number of the digital pin connected to the DIO pin of the module
@@ -127,6 +126,12 @@ public:
   //! @param flip - Flip display orientation (default=false)
   TM1637TinyDisplay(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay = DEFAULT_BIT_DELAY, 
     unsigned int scrollDelay = DEFAULT_SCROLL_DELAY, bool flip=DEFAULT_FLIP);
+
+  //! Initialize the display, setting the clock and data pins.
+  //!
+  //! This method should be called once (typically in setup()) before calling any other.
+  //! @note It may be unnecessary depending on your hardware configuration.
+  void begin();
 
   //! Sets the orientation of the display.
   //!

--- a/TM1637TinyDisplay6.cpp
+++ b/TM1637TinyDisplay6.cpp
@@ -184,6 +184,7 @@ void TM1637TinyDisplay6::begin()
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
+  clear();
 }
 
 void TM1637TinyDisplay6::flipDisplay(bool flip)

--- a/TM1637TinyDisplay6.cpp
+++ b/TM1637TinyDisplay6.cpp
@@ -174,14 +174,16 @@ TM1637TinyDisplay6::TM1637TinyDisplay6(uint8_t pinClk, uint8_t pinDIO,
   m_scrollDelay = scrollDelay;
   // Flip 
   m_flipDisplay = flip;
-  
+}
+
+void TM1637TinyDisplay6::begin()
+{
   // Set the pin direction and default value.
   // Both pins are set as inputs, allowing the pull-up resistors to pull them up
   pinMode(m_pinClk, INPUT);
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
-  clear();
 }
 
 void TM1637TinyDisplay6::flipDisplay(bool flip)

--- a/TM1637TinyDisplay6.h
+++ b/TM1637TinyDisplay6.h
@@ -117,8 +117,7 @@
 class TM1637TinyDisplay6 {
 
 public:
-  //! Initialize a TM1637TinyDisplay object, setting the clock and
-  //! data pins.
+  //! Initialize a TM1637TinyDisplay object.
   //!
   //! @param pinClk - The number of the digital pin connected to the clock pin of the module
   //! @param pinDIO - The number of the digital pin connected to the DIO pin of the module
@@ -127,6 +126,12 @@ public:
   //! @param flip - Flip display orientation (default=false)
   TM1637TinyDisplay6(uint8_t pinClk, uint8_t pinDIO, unsigned int bitDelay = DEFAULT_BIT_DELAY, 
     unsigned int scrollDelay = DEFAULT_SCROLL_DELAY, bool flip=DEFAULT_FLIP);
+
+  //! Initialize the display, setting the clock and data pins.
+  //!
+  //! This method should be called once (typically in setup()) before calling any other.
+  //! @note It may be unnecessary depending on your hardware configuration.
+  void begin();
 
   //! Sets the orientation of the display.
   //!

--- a/examples/ATtiny85/ATtiny85.ino
+++ b/examples/ATtiny85/ATtiny85.ino
@@ -329,6 +329,8 @@ const PROGMEM char FlashString[] = "Flash Test - 1234567890"; // Must be globall
 const PROGMEM char FlashString2[] = "good";
 
 void setup() {
+  display.begin();
+  display.clear();
   display.setBrightness(BRIGHT_7);
 }
 

--- a/examples/TM1637-6Digit-Test/TM1637-6Digit-Test.ino
+++ b/examples/TM1637-6Digit-Test/TM1637-6Digit-Test.ino
@@ -156,8 +156,9 @@ TM1637TinyDisplay6 display(CLK, DIO);
 
 void setup()
 {
-  display.setBrightness(BRIGHT_HIGH);
+  display.begin();
   display.clear();
+  display.setBrightness(BRIGHT_HIGH);
 }
 
 void loop()

--- a/examples/TM1637-Countdown-Buttons/TM1637-Countdown-Buttons.ino
+++ b/examples/TM1637-Countdown-Buttons/TM1637-Countdown-Buttons.ino
@@ -55,8 +55,9 @@ int Sec = 0;
 
 void setup()
 {
-  display.setBrightness(BRIGHT_HIGH);
+  display.begin();
   display.clear();
+  display.setBrightness(BRIGHT_HIGH);
 
   pinMode(BUTTON_UP, INPUT_PULLUP);
   pinMode(BUTTON_DOWN, INPUT_PULLUP);

--- a/examples/TM1637-Countdown/TM1637-Countdown.ino
+++ b/examples/TM1637-Countdown/TM1637-Countdown.ino
@@ -47,8 +47,9 @@ unsigned long countDown;
 
 void setup()
 {
-  display.setBrightness(BRIGHT_HIGH);
+  display.begin();
   display.clear();
+  display.setBrightness(BRIGHT_HIGH);
 
   // Record Epoch - Same as Timer Reset
   startTime = millis();

--- a/examples/TM1637-NonBlockingAnimate/TM1637-NonBlockingAnimate.ino
+++ b/examples/TM1637-NonBlockingAnimate/TM1637-NonBlockingAnimate.ino
@@ -120,6 +120,8 @@ TM1637TinyDisplay display(CLK, DIO);
 void setup()
 {
   Serial.begin(9600);
+  display.begin();
+  display.clear();
   display.setBrightness(BRIGHT_HIGH);
   AnimationNum = 0;
 }

--- a/examples/TM1637Demo/TM1637Demo.ino
+++ b/examples/TM1637Demo/TM1637Demo.ino
@@ -321,6 +321,8 @@ const uint8_t ANIMATION3[218][4] PROGMEM = {
 };
 
 void setup() {
+  display.begin();
+  display.clear();
   display.setBrightness(BRIGHT_7);
   display.showNumber(1234);
   delay(1000);

--- a/examples/TM1637Test/TM1637Test.ino
+++ b/examples/TM1637Test/TM1637Test.ino
@@ -105,6 +105,8 @@ TM1637TinyDisplay display(CLK, DIO);
 
 void setup()
 {
+  display.begin();
+  display.clear();
 }
 
 void loop()

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,7 @@ TM1637TinyDisplay6	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
+begin	KEYWORD2
 setBrightness	KEYWORD2
 setSegments	KEYWORD2
 setScrolldelay	KEYWORD2
@@ -60,7 +61,6 @@ BRIGHT_4	LITERAL1
 BRIGHT_5	LITERAL1
 BRIGHT_6	LITERAL1
 BRIGHT_7	LITERAL1
-BRIGHT_8	LITERAL1
 BRIGHT_HIGH	LITERAL1
 
 ON	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TM1637TinyDisplay
-version=1.7.1
+version=1.8.0
 author=Jason Cox <jason@jasonacox.com>
 maintainer=Jason Cox <jason@jasonacox.com>
 sentence=A simple library to display numbers, text and animation on 4 and 6 digit 7-segment TM1637 based display modules. Offers non-blocking animations and scrolling!


### PR DESCRIPTION
Updated library operation to include an initializing method `begin()` to move outside the constructor hardware related calls, as reported in https://github.com/jasonacox/TM1637TinyDisplay/issues/28

Worth mentioning this [Arduino document about digital pins](https://docs.arduino.cc/learn/microcontrollers/digital-pins), as it's relevant to understand how the library operates with the communication line using `pinMode()` instead of `digitalWrite()` to drive it.

As requested, the *offending* calls where moved to `begin()` and ALL the examples updated. Keywords, Library properties and RELEASE were also updated accordingly.

I just have one display available (a Robotdyn's) and only Arduino boards to test it, so my checks are limited, but I'm pretty sure (after reading the code) that the `begin()` method call is, in reality, completely optional, as I *somehow* mention in the method docstring. That's also why I removed the `clear()`call from the method and put it at the top user-level. The good news here are that **preexisting code** will **still work** anyway.

Please, feel free to amend anything you want: I took the liberty to upgrade the release number to 1.8.0 as it is a significant change, but you decide.

Best regards!