### PR TITLE
Remove clean and set brightness from begin

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,35 @@
 # Release Notes for TM1637TinyDisplay
 
+## v1.12.0 - Clear Display Option
+
+* Update `begin()` function to allow parameter control of display clear and full brightness setting. Default behavior if not specified will be `true` which is the behavior with prior version.
+* Remove clean and set brightness from begin by @smaryus in https://github.com/jasonacox/TM1637TinyDisplay/pull/42.
+
+```cpp
+//! Initialize the display, setting the clock and data pins.
+//!
+//! This method should be called once (typically in setup()) before calling any other.
+//! @note It may be unnecessary depending on your hardware configuration.
+void begin();
+//! @param clearDisplay - Clear display and set the brightness to maximum value.
+void begin(bool clearDisplay=true);
+
+void TM1637TinyDisplay::begin(bool clearDisplay)
+{
+  // Set the pin direction and default value.
+  // Both pins are set as inputs, allowing the pull-up resistors to pull them up
+  pinMode(m_pinClk, INPUT);
+  pinMode(m_pinDIO, INPUT);
+  digitalWrite(m_pinClk, LOW);
+  digitalWrite(m_pinDIO, LOW);
+  if (clearDisplay)
+  {
+    clear();
+    setBrightness(BRIGHT_HIGH);
+  }
+}
+```
+
 ## v1.11.0 - Enhanced Character Set
 
 * Updated character set by @J-Brinkman in https://github.com/jasonacox/TM1637TinyDisplay/issues/39

--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -183,8 +183,6 @@ void TM1637TinyDisplay::begin()
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
-  clear();
-  setBrightness(BRIGHT_HIGH);
 }
 
 void TM1637TinyDisplay::flipDisplay(bool flip)

--- a/TM1637TinyDisplay.cpp
+++ b/TM1637TinyDisplay.cpp
@@ -175,7 +175,7 @@ TM1637TinyDisplay::TM1637TinyDisplay(uint8_t pinClk, uint8_t pinDIO, unsigned in
   m_flipDisplay = flip;
 }
 
-void TM1637TinyDisplay::begin()
+void TM1637TinyDisplay::begin(bool clearDisplay)
 {
   // Set the pin direction and default value.
   // Both pins are set as inputs, allowing the pull-up resistors to pull them up
@@ -183,6 +183,11 @@ void TM1637TinyDisplay::begin()
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
+  if (clearDisplay)
+  {
+    clear();
+    setBrightness(BRIGHT_HIGH);
+  }
 }
 
 void TM1637TinyDisplay::flipDisplay(bool flip)

--- a/TM1637TinyDisplay.h
+++ b/TM1637TinyDisplay.h
@@ -131,7 +131,8 @@ public:
   //!
   //! This method should be called once (typically in setup()) before calling any other.
   //! @note It may be unnecessary depending on your hardware configuration.
-  void begin();
+  //! @param clearDisplay - Clear display and set the brightness to maximum value.
+  void begin(bool clearDisplay=true);
 
   //! Sets the orientation of the display.
   //!

--- a/TM1637TinyDisplay6.cpp
+++ b/TM1637TinyDisplay6.cpp
@@ -178,7 +178,7 @@ TM1637TinyDisplay6::TM1637TinyDisplay6(uint8_t pinClk, uint8_t pinDIO,
   m_flipDisplay = flip;
 }
 
-void TM1637TinyDisplay6::begin()
+void TM1637TinyDisplay6::begin(bool clearDisplay)
 {
   // Set the pin direction and default value.
   // Both pins are set as inputs, allowing the pull-up resistors to pull them up
@@ -186,8 +186,11 @@ void TM1637TinyDisplay6::begin()
   pinMode(m_pinDIO, INPUT);
   digitalWrite(m_pinClk, LOW);
   digitalWrite(m_pinDIO, LOW);
-  clear();
-  setBrightness(BRIGHT_HIGH);
+  if (clearDisplay)
+  {
+    clear();
+    setBrightness(BRIGHT_HIGH);
+  }
 }
 
 void TM1637TinyDisplay6::flipDisplay(bool flip)

--- a/TM1637TinyDisplay6.h
+++ b/TM1637TinyDisplay6.h
@@ -131,7 +131,8 @@ public:
   //!
   //! This method should be called once (typically in setup()) before calling any other.
   //! @note It may be unnecessary depending on your hardware configuration.
-  void begin();
+  //! @param clearDisplay - Clear display and set the brightness to maximum value.
+  void begin(bool clearDisplay=true);
 
   //! Sets the orientation of the display.
   //!

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TM1637TinyDisplay
-version=1.11.0
+version=1.12.0
 author=Jason Cox <jason@jasonacox.com>
 maintainer=Jason Cox <jason@jasonacox.com>
 sentence=A simple library to display numbers, text and animation on 4 and 6 digit 7-segment TM1637 based display modules. Offers non-blocking animations and scrolling!


### PR DESCRIPTION
Remove clean and set brightness from begin method  because on ESP8266 when resuming from deep sleep would create flickering. This is because ESP8266 when it wakes up from deep sleep the device does a restart, which would invoke begin().